### PR TITLE
Answer login queries with an index

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -11,7 +11,7 @@ create table auth_users (
 	is_staff integer default 0,
 	is_admin integer default 0
 );
-create unique index user_login_idx ON auth_users(username, salt, hashword)
+create unique index user_login_idx ON auth_users(username, salt, hashword);
 
 drop table if exists idea_stubs;
 create table idea_stubs (


### PR DESCRIPTION
Adds a multicolumn index to the auth_users table so that we can answer login queries from the index rather than from the table itself.

This might qualify as a premature optimization, but I thought of it while working on the scrypt change and it only took a few minutes to implement.
