### PR TITLE
Just use a pip requirements file for tracking dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,7 @@
+Flask==0.10.1
+Jinja2==2.7.1
+MarkupSafe==0.18
+Werkzeug==0.9.4
+itsdangerous==0.23
+scrypt==0.6.1
+wsgiref==0.1.2

--- a/installdeps.sh
+++ b/installdeps.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 
-pip install flask
-pip install scrypt
+pip install -r dev-requirements.txt
 


### PR DESCRIPTION
From the "why did I do it like that?" department: our only dependencies at this
point are python packages, so we can just rely on pip to do the dependency
tracking.

I generated dev-requirements.txt with `$ pip freeze > dev-requirements.txt`
from a working environment. It might be a Good Idea to just list flask and
scrypt without versions and just let the deps sort themselves out, but I'd
rather have it be explicit when we build out an environment for this.
