### PR TITLE
Configure ideawheel to have CI tests run by travis-ci.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.db
 .coverage
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+
+python: 
+  - "2.7"
+
+install: "pip install -r pip-requirements.txt"
+
+script: nosetests


### PR DESCRIPTION
Adds a basic .travis.yml to the project so that travis can run automated
tests against ideawheel. This allows us to have a nice, not-my-machine
option for running the ideawheel tests.

Also updates .gitignore to ignore emacs editor files in case someone has
forgotten to include that in their global git ignores.